### PR TITLE
Bug: Don't scan schemas that don't exist

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -181,7 +181,7 @@ class AthenaAdapter(SQLAdapter):
         paginator = glue_client.get_paginator('get_databases')
         kwargs = {}
         if catalog_id:
-            kwargs['CatalogId'] = catalog_id        
+            kwargs['CatalogId'] = catalog_id
         page_iterator = paginator.paginate(**kwargs)
 
         databases = []

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -176,6 +176,22 @@ class AthenaAdapter(SQLAdapter):
         client = conn.handle
         with boto3_client_lock:
             glue_client = boto3.client('glue', region_name=client.region_name)
+
+        # check for database existence before getting tables
+        paginator = glue_client.get_paginator('get_databases')
+        kwargs = {}
+        if catalog_id:
+            kwargs['CatalogId'] = catalog_id        
+        page_iterator = paginator.paginate(**kwargs)
+
+        databases = []
+        for page in page_iterator:
+            for db in page["DatabaseList"]:
+                databases.append(db["Name"])
+
+        if schema_relation.schema not in databases:
+            return []
+
         paginator = glue_client.get_paginator('get_tables')
 
         kwargs = {


### PR DESCRIPTION
When running a hybrid dbt model with some Athena schemas and some non-Athena schemas, `list_relations_without_caching` would fail when trying to scan the non-Athena schemas for tables.

```
Partial parse save file not found. Starting full parse.
Found 54 models, 236 tests, 11 snapshots, 0 analyses, 417 macros, 4 operations, 4 seed files, 10 sources, 0 exposures, 0 metrics

Encountered an error:
An error occurred (EntityNotFoundException) when calling the GetTables operation: Database dbt_snapshots not found.
```

This change checks if a schema exists in the Glue catalog before calling GetTables on it to make sure this edge case doesn't happen.