### PR TITLE
Add unique suffix to temp table names

### DIFF
--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -6,3 +6,15 @@
     drop {{ relation.type }} if exists {{ relation }}
   {%- endcall %}
 {% endmacro %}
+
+
+{% macro athena__unique_suffix() %}
+  {%- set query -%}
+  SELECT 
+    '__tmp_' || 
+    cast(cast(to_unixtime(now()) as int) as varchar) || '_' || 
+    cast(cast(random() * 1000000 as int) as varchar)
+  {%- endset -%}
+
+  {{ return(run_query(query)[0][0]) }}
+{% endmacro %}

--- a/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -14,7 +14,8 @@
   {% set partitioned_by = config.get('partitioned_by', default=none) %}
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
-  {% set tmp_relation = make_temp_relation(this) %}
+  {% set tmp_suffix = athena__unique_suffix() %}
+  {% set tmp_relation = make_temp_relation(this, tmp_suffix) %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
@@ -28,7 +29,7 @@
       {% do adapter.drop_relation(existing_relation) %}
       {% set build_sql = create_table_as(False, target_relation, sql) %}
   {% elif partitioned_by is not none and strategy == 'insert_overwrite' %}
-      {% set tmp_relation = make_temp_relation(target_relation) %}
+      {% set tmp_relation = make_temp_relation(target_relation, tmp_suffix) %}
       {% if tmp_relation is not none %}
           {% do adapter.drop_relation(tmp_relation) %}
       {% endif %}
@@ -37,7 +38,7 @@
       {% set build_sql = incremental_insert(tmp_relation, target_relation) %}
       {% do to_drop.append(tmp_relation) %}
   {% else %}
-      {% set tmp_relation = make_temp_relation(target_relation) %}
+      {% set tmp_relation = make_temp_relation(target_relation, tmp_suffix) %}
       {% if tmp_relation is not none %}
           {% do adapter.drop_relation(tmp_relation) %}
       {% endif %}


### PR DESCRIPTION
Add a unique suffix to temp table names to allow dbt runs of the same model to run in parallel