### PR TITLE
Create an external_location if none is provided

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -54,6 +54,13 @@ class AthenaAdapter(SQLAdapter):
         return f"{client.s3_staging_dir}tables/{str(uuid4())}/"
 
     @available
+    def s3_staging_dir(self):
+        conn = self.connections.get_thread_connection()
+        client = conn.handle
+
+        return client.s3_staging_dir
+
+    @available
     def clean_up_partitions(
         self, database_name: str, table_name: str, where_condition: str
     ):

--- a/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -13,7 +13,7 @@
   {% endif %}
 
   {% set partitioned_by = config.get('partitioned_by', default=none) %}
-  {% set external_location = config.get('external_location') %}
+  {% set external_location = config.get('external_location', default=none) %}
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
   {% set tmp_suffix = athena__unique_suffix() %}
@@ -34,7 +34,11 @@
       {% for col in dest_columns %}
         {% do column_list.append(col.name ~ ' ' ~ safe_athena_type(col.data_type)) %}
       {% endfor %}
-      
+
+      {% if external_location is none %}
+        {% set external_location = adapter.s3_staging_dir() ~ target_relation.name %}
+      {% endif %}
+
       {% do run_query(create_iceberg_table(target_relation, column_list, partitioned_by, external_location)) %}
   {% endif %}
 


### PR DESCRIPTION
If `external_location` was not provided in an Iceberg model's config, Iceberg create would fail. Since this is usually just some bucket + table name, just create that using existing `s3_staging_dir` adapter setting. `external_location` in model config overrides this default.