### PR TITLE
Bug: Merge with partitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ cython_debug/
 test.py
 test_model
 test_profile
+logs/
+.user.yml

--- a/test/test_models/.dbt/profiles.yml
+++ b/test/test_models/.dbt/profiles.yml
@@ -1,0 +1,11 @@
+dbt_test_athena:
+  target: "test"
+  outputs:
+    test:
+      type: athena
+      s3_staging_dir: "{{ env_var('DBT_TEST_ATHENA_S3_STAGING_DIR') }}"
+      schema: "{{ env_var('DBT_TEST_ATHENA_SCHEMA') }}"
+      work_group: "{{ env_var('DBT_TEST_ATHENA_WORKGROUP') }}"
+      region_name: "{{ env_var('DBT_TEST_ATHENA_REGION') }}"
+      database: "{{ env_var('DBT_TEST_ATHENA_DATABASE', 'awsdatacatalog') }}"
+      threads: 2

--- a/test/test_models/dbt_project.yml
+++ b/test/test_models/dbt_project.yml
@@ -1,0 +1,24 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'dbt_test_athena'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'dbt_test_athena'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"

--- a/test/test_models/models/iceberg/test_merge.sql
+++ b/test/test_models/models/iceberg/test_merge.sql
@@ -1,0 +1,28 @@
+{{ config(
+    materialized='incremental',
+    format='ICEBERG',
+    tags=['dbt_test_athena', 'iceberg'],
+    incremental_strategy='merge',
+    unique_key='primary_key'
+) }}
+
+WITH stage_data as (
+    SELECT
+        'key_001' as primary_key,
+        '{{ var("name") }}' as name,
+        '{{ var("email") }}' as email
+
+    {% if var('include_dave') == 'true' %}
+    UNION ALL
+
+    SELECT
+        'key_002' as primary_key,
+        'Dave Patterson' as name,
+        'david.patterson@example.com' as email
+    {% endif %}
+)
+SELECT
+    stage_data.primary_key,
+    stage_data.name,
+    stage_data.email
+FROM stage_data

--- a/test/test_models/models/iceberg/test_merge_partitioned.sql
+++ b/test/test_models/models/iceberg/test_merge_partitioned.sql
@@ -1,0 +1,30 @@
+{{ config(
+    materialized='incremental',
+    format='ICEBERG',
+    tags=['dbt_test_athena', 'iceberg'],
+    partitioned_by=['partition_key'],
+    incremental_strategy='merge',
+    unique_key='primary_key'
+) }}
+
+WITH stage_data as (
+    SELECT
+        'key_001_{{ var("partition_key") }}' as primary_key,
+        'Tom Jones' as name,
+        'tom.jones@example.com' as email,
+        '{{ var("partition_key") }}' as partition_key
+
+    UNION ALL
+
+    SELECT
+        'key_002_{{ var("partition_key") }}' as primary_key,
+        'Dave Patterson' as name,
+        'david.patterson@example.com' as email,
+        '{{ var("partition_key") }}' as partition_key
+)
+SELECT
+    stage_data.primary_key,
+    stage_data.name,
+    stage_data.email,
+    stage_data.partition_key
+FROM stage_data


### PR DESCRIPTION
Fix a bug in the `merge` incremental mode where models with `partitioned_by` columns could have data deleted by the merge operation. 

The insert/delete/merge operations now look like the below queries:

1. Stage new changes
```sql
create table
    athena_dbt_test.test_merge_partitioned__tmp_1666116512_51320

    with (
        partitioned_by=ARRAY['partition_key'],
        format='parquet'
    )
  as
    

WITH stage_data as (
    SELECT
        'key_001_tenant_a' as primary_key,
        'Tom Jones' as name,
        'tom.jones@example.com' as email,
        'tenant_a' as partition_key

    UNION ALL

    SELECT
        'key_002_tenant_a' as primary_key,
        'Dave Patterson' as name,
        'david.patterson@example.com' as email,
        'tenant_a' as partition_key
)
SELECT
    stage_data.primary_key,
    stage_data.name,
    stage_data.email,
    stage_data.partition_key
FROM stage_data
```
2. Store unchanged rows from the existing table, only selecting rows that are in partitions contained in the changed table
```sql
create table
  athena_dbt_test.test_merge_partitioned__tmp_1666116529_377380

  with (
      partitioned_by=ARRAY['partition_key'],
      format='parquet'
  )
as
  with existing as (
  select
  primary_key as dbt__unique_key,
  primary_key, name, email, partition_key
  from athena_dbt_test.test_merge_partitioned
  -- NEW
  where (partition_key='tenant_a')
  
),
new as (
  select
  primary_key as dbt__unique_key,
  primary_key, name, email, partition_key
  from athena_dbt_test.test_merge_partitioned__tmp_1666116512_51320
  -- NEW
  where (partition_key='tenant_a')
  
)
select
existing.primary_key, existing.name, existing.email, existing.partition_key
from existing left join new on existing.dbt__unique_key=new.dbt__unique_key
where new.dbt__unique_key is null
```
3. Delete all records for partitions contained in changed temp table
```sql
delete from athena_dbt_test.test_merge_partitioned
-- NEW
where (partition_key='tenant_a')
```
4. Merge new changes and existing records back into existing table
```sql
insert into athena_dbt_test.test_merge_partitioned ("primary_key", "name", "email", "partition_key")
(
   -- new changes
   select "primary_key", "name", "email", "partition_key"
   from athena_dbt_test.test_merge_partitioned__tmp_1666116512_51320

   union all
   -- existing records
   select "primary_key", "name", "email", "partition_key"
   from athena_dbt_test.test_merge_partitioned__tmp_1666116529_377380
);
```

### Testing

I ran the included `test_merge_partitioned.sql` model twice for two partition_keys, `tenant_a` and `tenant_b`. After running the second time to ensure deletes happen, all 4 expected records are present in the table:

<img width="946" alt="Screen Shot 2022-10-18 at 11 38 31 AM" src="https://user-images.githubusercontent.com/3154120/196516148-fa6ed660-d1e3-4eb0-803b-679a99ce5826.png">