### PR TITLE
Fix GetPartitions bug

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -90,7 +90,6 @@ class AthenaAdapter(SQLAdapter):
                 bucket_name = m.group(1)
                 prefix = m.group(2)
                 s3_bucket = s3_resource.Bucket(bucket_name)
-                # s3_bucket.object_versions.filter(Prefix=prefix).delete()
                 s3_bucket.objects.filter(Prefix=prefix).delete()
 
     @available


### PR DESCRIPTION
Bug behavior: `insert_overwrite` would sometimes not delete old data before inserting new data.

Root cause: On some large Glue tables, `GetPartitions` doesn't return partitions as expected. However, using `BatchGetPartition` with the same values is reliable:

```python
partitions = glue_client.get_partitions(DatabaseName="stack_athena_main", TableName="events", Expression="tenant='tenant' and status='deduped' and date='2022-11-15'")
print(partitions)
# {'Partitions': []}

>>> partitions = glue_client.batch_get_partition(DatabaseName="stack_athena_main", TableName="events", PartitionsToGet=[{'Values': ['tenant', 'deduped', '2022-11-15']}])
>>> print(partitions)
# {'Partitions': [{'Values': ['tenant', 'deduped', '2022-11-15'], 'DatabaseName': 'stack_athena_main', 'TableName': 'events', 'CreationTime': datetime.datetime(2022, 11, 16, 5, 5, 23, tzinfo=tzlocal())...
```
